### PR TITLE
FEAT: cleanup

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -49,23 +49,16 @@ type Item struct {
 }
 
 // NewAWS creates a new instance of the AWS structure
-func NewAWS(region string) (*AWS, error) {
+func NewAWS() (*AWS, error) {
 	var a AWS
 	var sess *session.Session
 
-	// Configure session with credentials from .aws/credentials and region...
-	if region != "" {
-		// ... from region param
-		config := &aws.Config{
-			Region: aws.String(region),
-		}
-		sess = session.Must(session.NewSession(config))
-	} else {
-		// ... from .aws/config
-		sess = session.Must(session.NewSessionWithOptions(session.Options{
-			SharedConfigState: session.SharedConfigEnable,
-		}))
-	}
+	// Configure session with credentials from .aws/credentials or env and
+	// region from .aws/config or env
+	sess = session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
+
 	if sess == nil {
 		return nil, errors.New("AWS session is nil")
 	}

--- a/configuration.go
+++ b/configuration.go
@@ -26,10 +26,6 @@ import (
 // Configuration details from appsettings.json for access to the AWS or Azure
 // storage.
 type Configuration struct {
-	AzureAccessKey  string `json:"azureAccessKey"`
-	AzureAccount    string `json:"azureAccount"`
-	UseDynamoDB     bool   `json:"useDynamoDB"`
-	AWSRegion       string `json:"awsRegion"`
 	BackgroundColor string `json:"backgroundColor"`
 	MessageColor    string `json:"messageColor"`
 	Debug           bool   `json:"debug"`
@@ -64,14 +60,6 @@ func (c *Configuration) Validate() error {
 			log.Printf("OWID:MessageColor: %s\n", c.MessageColor)
 		} else {
 			err = fmt.Errorf("OWID MessageColor missing in config")
-		}
-	}
-	if err == nil {
-		if c.AzureAccessKey == "" && c.AzureAccount == "" &&
-			c.UseDynamoDB == false && c.AWSRegion == "" {
-			err = fmt.Errorf(
-				"OWID Either Azure table storage or AWS Dynamo DB " +
-					"parameters must be set.")
 		}
 	}
 	return err

--- a/crypto.go
+++ b/crypto.go
@@ -113,7 +113,7 @@ func (c *Crypto) Sign(date time.Time, payload []byte) (string, error) {
 		return "", err
 	}
 
-	return base64.StdEncoding.EncodeToString([]byte(signature)), nil
+	return base64.RawURLEncoding.EncodeToString([]byte(signature)), nil
 }
 
 // Verify extracts the signature from an OWID and verifies that is has
@@ -138,7 +138,7 @@ func (c *Crypto) Verify(id string) (bool, error) {
 	date := buf.Bytes()
 
 	hashed := sha256.Sum256(append(o.Payload, date...))
-	decoded, err := base64.StdEncoding.DecodeString(o.Signature)
+	decoded, err := base64.RawURLEncoding.DecodeString(o.Signature)
 	if err != nil {
 		return false, err
 	}

--- a/owid.go
+++ b/owid.go
@@ -80,13 +80,13 @@ func (o *OWID) EncodeAsBase64() (string, error) {
 		return "", err
 	}
 
-	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
+	return base64.RawURLEncoding.EncodeToString(buf.Bytes()), nil
 }
 
 // DecodeFromBase64 decodes a Base 64 string into an OWID
 func DecodeFromBase64(owid string) (*OWID, error) {
 	var o OWID
-	b, err := base64.StdEncoding.DecodeString(owid)
+	b, err := base64.RawURLEncoding.DecodeString(owid)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Use base64 URL encoding always when dealing with base64 strings to prevent issues when transmitting base64 strings over the web.
- Use environment variables or .aws/config for configuring AWS region.